### PR TITLE
Fixing Bug with Install Button Shifting Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@ that asks what room you want to go to -->
   <body>
     <main>
       <div style="text-align:center">
-        <button id="installButton" class="center" style="display: none;"> 
+        <button id="installButton" style="display: none;"> 
           Install as app
         </button>
         <h1 > Where do you need to go? </h1>

--- a/maybeInstallApp.js
+++ b/maybeInstallApp.js
@@ -9,7 +9,7 @@ window.addEventListener('beforeinstallprompt', (e) => {
   // Stash the event so it can be triggered later.
   deferredPrompt = e;
 
-  btnAdd.style.display = "block";
+  btnAdd.style.display = '';
 });
 
 btnAdd.addEventListener('click', (e) => {


### PR DESCRIPTION
Before these changes, the install button would shift the page up and down when hovering over it:
![sorry the mouse is offset from where it actually is](https://cdn.discordapp.com/attachments/510610831692529681/637884033778319370/r55fU5JEt0.gif)

Now the page stays positioned where it should be:
![sorry the mouse is offset from where it actually is](https://cdn.discordapp.com/attachments/510610831692529681/637883683331637280/ZyXxjQhE1g.gif)