### PR TITLE
Improve PWA update process

### DIFF
--- a/src/components/settings/CheckUpdatesButton.vue
+++ b/src/components/settings/CheckUpdatesButton.vue
@@ -10,7 +10,10 @@
 </template>
 
 <script lang="ts">
+/// <reference path="../../vue-snack-vue-property.d.ts" />
+
 import Vue from "vue";
+import { refreshToUpdate } from "@/showMessageOnNextPageReload";
 
 export default Vue.extend({
   data() {
@@ -19,19 +22,14 @@ export default Vue.extend({
   methods: {
     checkForUpdates(): void {
       document.dispatchEvent(new Event("check-for-updates"));
+      document.addEventListener("needs-refresh", refreshToUpdate);
       this.spin = true;
-      let updateFound = false;
-      document.addEventListener("refresh-snackbar", () => {
-        updateFound = true;
-      });
       setTimeout(() => {
         this.spin = false;
-        if (!updateFound) {
-          (this as any).$snack.show({
-            text: "No updates found",
-            button: "",
-          });
-        }
+        this.$snack.show({
+          text: "No updates found",
+          button: "",
+        });
       }, 1000);
     },
   },

--- a/src/components/settings/CheckUpdatesButton.vue
+++ b/src/components/settings/CheckUpdatesButton.vue
@@ -21,15 +21,18 @@ export default Vue.extend({
   },
   methods: {
     checkForUpdates(): void {
-      document.dispatchEvent(new Event("check-for-updates"));
       document.addEventListener("needs-refresh", refreshToUpdate);
+      document.dispatchEvent(new Event("check-for-updates"));
       this.spin = true;
       setTimeout(() => {
+        document.removeEventListener("needs-refresh", refreshToUpdate);
         this.spin = false;
-        this.$snack.show({
-          text: "No updates found",
-          button: "",
-        });
+        if (!(window as any).needsRefresh) {
+          this.$snack.show({
+            text: "No updates found",
+            button: "",
+          });
+        }
       }, 1000);
     },
   },

--- a/src/components/settings/CheckUpdatesButton.vue
+++ b/src/components/settings/CheckUpdatesButton.vue
@@ -33,7 +33,7 @@ export default Vue.extend({
             button: "",
           });
         }
-      }, 1000);
+      }, 4000);
     },
   },
 });
@@ -54,8 +54,8 @@ export default Vue.extend({
 
 .spin {
   animation-name: spin;
-  animation-duration: 1s;
-  animation-iteration-count: 1;
+  animation-duration: 1.333s;
+  animation-iteration-count: 3;
   animation-timing-function: linear;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+/// <reference path="./vue-snack-vue-property.d.ts" />
+
 // polyfill needed for vue-snack IE support
 import "core-js/features/array/from";
 
@@ -12,7 +14,7 @@ import "@/registerServiceWorker";
 import store from "./store";
 import {
   messageOnNextPageReloadKey,
-  showMessageOnNextPageReload,
+  refreshToUpdate,
 } from "./showMessageOnNextPageReload";
 
 Vue.use(VueSnackbar, { close: true });
@@ -39,13 +41,10 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 });
 
-document.addEventListener("refresh-snackbar", () => {
-  (vm as any).$snack.show({
+document.addEventListener("needs-refresh", () => {
+  vm.$snack.show({
     text: "New update for site is available",
     button: "refresh to update",
-    action: () => {
-      showMessageOnNextPageReload("Updated site");
-      window.location.reload();
-    },
+    action: refreshToUpdate,
   });
 });

--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -4,6 +4,14 @@ import { register } from "register-service-worker";
 
 (window as any).needsRefresh = false;
 
+let lastUpdated = 0;
+function throttledCheckForUpdates() {
+  if (Date.now() - lastUpdated >= 10 * 1000) {
+    document.dispatchEvent(new Event("check-for-updates"));
+    lastUpdated = Date.now();
+  }
+}
+
 if (process.env.NODE_ENV === "production") {
   register(`${process.env.BASE_URL}service-worker.js`, {
     ready() {
@@ -12,12 +20,10 @@ if (process.env.NODE_ENV === "production") {
     registered(registration: ServiceWorkerRegistration) {
       console.log("Service worker has been registered.");
       // Check for new version of service worker every 45 minutes
-      setInterval(() => {
-        document.dispatchEvent(new Event("check-for-updates"));
-      }, 1000 * 60 * 45);
+      setInterval(throttledCheckForUpdates, 1000 * 60 * 45);
       document.addEventListener("visibilitychange", () => {
         if (document.visibilityState === "visible") {
-          document.dispatchEvent(new Event("check-for-updates"));
+          throttledCheckForUpdates();
         }
       });
 

--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -2,7 +2,7 @@
 
 import { register } from "register-service-worker";
 
-let needsRefresh = false;
+(window as any).needsRefresh = false;
 
 if (process.env.NODE_ENV === "production") {
   register(`${process.env.BASE_URL}service-worker.js`, {
@@ -22,7 +22,7 @@ if (process.env.NODE_ENV === "production") {
       });
 
       document.addEventListener("check-for-updates", () => {
-        if (needsRefresh) {
+        if ((window as any).needsRefresh) {
           document.dispatchEvent(new Event("needs-refresh"));
         } else {
           registration.update();
@@ -37,7 +37,7 @@ if (process.env.NODE_ENV === "production") {
     },
     updated() {
       console.log("New content is available; please refresh.");
-      needsRefresh = true;
+      (window as any).needsRefresh = true;
       document.dispatchEvent(new Event("needs-refresh"));
     },
     offline() {

--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -32,10 +32,12 @@ if (process.env.NODE_ENV === "production") {
       // https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#manual_updates)
 
       document.addEventListener("check-for-updates", () => {
+        // We want to check for a new version even if we know we need
+        // a refresh because there could have been a second update.
+        registration.update();
+
         if ((window as any).needsRefresh) {
           document.dispatchEvent(new Event("needs-refresh"));
-        } else {
-          registration.update();
         }
       });
     },

--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -5,8 +5,9 @@ import { register } from "register-service-worker";
 (window as any).needsRefresh = false;
 
 let lastUpdated = 0;
+const SECONDS_TO_THROTTLE = 60;
 function throttledCheckForUpdates() {
-  if (Date.now() - lastUpdated >= 10 * 1000) {
+  if (Date.now() - lastUpdated >= SECONDS_TO_THROTTLE * 1000) {
     document.dispatchEvent(new Event("check-for-updates"));
     lastUpdated = Date.now();
   }

--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -2,6 +2,8 @@
 
 import { register } from "register-service-worker";
 
+let needsRefresh = false;
+
 if (process.env.NODE_ENV === "production") {
   register(`${process.env.BASE_URL}service-worker.js`, {
     ready() {
@@ -16,7 +18,11 @@ if (process.env.NODE_ENV === "production") {
       }, 1000 * 60 * 45);
 
       document.addEventListener("check-for-updates", () => {
-        registration.update();
+        if (needsRefresh) {
+          document.dispatchEvent(new Event("needs-refresh"));
+        } else {
+          registration.update();
+        }
       });
     },
     cached() {
@@ -27,7 +33,8 @@ if (process.env.NODE_ENV === "production") {
     },
     updated() {
       console.log("New content is available; please refresh.");
-      document.dispatchEvent(new Event("refresh-snackbar"));
+      needsRefresh = true;
+      document.dispatchEvent(new Event("needs-refresh"));
     },
     offline() {
       console.log(

--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -13,9 +13,13 @@ if (process.env.NODE_ENV === "production") {
       console.log("Service worker has been registered.");
       // Check for new version of service worker every 45 minutes
       setInterval(() => {
-        console.log("Checking for updates");
-        registration.update();
+        document.dispatchEvent(new Event("check-for-updates"));
       }, 1000 * 60 * 45);
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "visible") {
+          document.dispatchEvent(new Event("check-for-updates"));
+        }
+      });
 
       document.addEventListener("check-for-updates", () => {
         if (needsRefresh) {

--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -21,11 +21,15 @@ if (process.env.NODE_ENV === "production") {
       console.log("Service worker has been registered.");
       // Check for new version of service worker every 45 minutes
       setInterval(throttledCheckForUpdates, 1000 * 60 * 45);
+      // Check for new version when window comes into focus
       document.addEventListener("visibilitychange", () => {
         if (document.visibilityState === "visible") {
           throttledCheckForUpdates();
         }
       });
+      // Browser automatically checks for a new version when page loads
+      // ("A navigation to an in-scope page." in https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle,
+      // https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#manual_updates)
 
       document.addEventListener("check-for-updates", () => {
         if ((window as any).needsRefresh) {

--- a/src/showMessageOnNextPageReload.ts
+++ b/src/showMessageOnNextPageReload.ts
@@ -3,3 +3,8 @@ export const messageOnNextPageReloadKey = "messageOnNextPageReload";
 export function showMessageOnNextPageReload(message: string) {
   sessionStorage.setItem(messageOnNextPageReloadKey, message);
 }
+
+export function refreshToUpdate() {
+  showMessageOnNextPageReload("Updated site");
+  window.location.reload();
+}

--- a/src/vue-snack-vue-property.d.ts
+++ b/src/vue-snack-vue-property.d.ts
@@ -1,0 +1,11 @@
+import Vue from "vue";
+
+declare module "vue/types/vue" {
+  interface Vue {
+    $snack: any;
+  }
+
+  interface VueConstructor {
+    $snack: any;
+  }
+}


### PR DESCRIPTION
- Keep track of needsRefresh so that we know whether a new refresh is needed, even if user declines to refresh
- Refresh without prompting when user presses "Check for updates" button and needsRefresh is true
- Check for updates when document becomes visible