### PR TITLE
More contrast for less-important-text-color

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -81,7 +81,7 @@ html[data-theme="light"] {
   --heading-text-color: #220d8a;
   --subheading-text-color: #204ba0;
   --par-text-color: #000000;
-  --less-important-text-color: #6f6f6f;
+  --less-important-text-color: #615f5f;
 
   --header-bar-text-color: #0b004b;
   --header-bar-selected-text-color: #2355b8;
@@ -123,7 +123,7 @@ html[data-theme="dark"] {
   --heading-text-color: #ccc9a9;
   --subheading-text-color: #fffcec;
   --par-text-color: #ffffff;
-  --less-important-text-color: #6f6f6f;
+  --less-important-text-color: #c4bfbf;
 
   --header-bar-text-color: #908414;
   --header-bar-selected-text-color: #dac92d;


### PR DESCRIPTION
Dark Mode before/after:

<img width="389" alt="image" src="https://user-images.githubusercontent.com/22969541/111888420-adeb6000-89b2-11eb-956f-209bb4e6ee50.png"> <img width="389" alt="image" src="https://user-images.githubusercontent.com/22969541/111888426-b6dc3180-89b2-11eb-878e-bb7e4f9e420d.png">

Light Mode before/after (not as much difference here):

<img width="389" alt="image" src="https://user-images.githubusercontent.com/22969541/111888432-cfe4e280-89b2-11eb-93d6-f97fed20dd6e.png"> <img width="389" alt="image" src="https://user-images.githubusercontent.com/22969541/111888434-d2dfd300-89b2-11eb-90e7-80bb2dcb819f.png">
