### PR TITLE
Disable hover on touch screens on My Schedule Edit page

### DIFF
--- a/src/components/buttons/MinusButton.vue
+++ b/src/components/buttons/MinusButton.vue
@@ -29,10 +29,15 @@ export default Vue.extend({
 }
 
 .btn-hover-area >>> .active-button:hover {
-  background: rgba(0, 0, 0, 0);
-  color: var(--minus-button-color-hover);
-  transition: var(--long-decay-ease);
   cursor: pointer;
-  border-radius: 7.5px;
+}
+
+@media (hover: hover) {
+  .btn-hover-area >>> .active-button:hover {
+    background: rgba(0, 0, 0, 0);
+    color: var(--minus-button-color-hover);
+    transition: var(--long-decay-ease);
+    border-radius: 7.5px;
+  }
 }
 </style>

--- a/src/components/buttons/PlusButton.vue
+++ b/src/components/buttons/PlusButton.vue
@@ -29,10 +29,15 @@ export default Vue.extend({
 }
 
 .btn-hover-area >>> .active-button:hover {
-  background-color: var(--plus-button-hover-color);
-  color: var(--button-text-color);
-  transition: var(--long-decay-ease);
   cursor: pointer;
-  border-radius: 25px;
+}
+
+@media (hover: hover) {
+  .btn-hover-area >>> .active-button:hover {
+    background-color: var(--plus-button-hover-color);
+    color: var(--button-text-color);
+    transition: var(--long-decay-ease);
+    border-radius: 25px;
+  }
 }
 </style>


### PR DESCRIPTION
Use the `@media (hover: hover)` media query to detect only devices where you can actually hover.

This only applies to the "+" and "-" buttons on the "My Schedule Edit" page.

fix #126