### PR TITLE
Remove COVID precautions in directions

### DIFF
--- a/src/walnut/shared.ts
+++ b/src/walnut/shared.ts
@@ -1,6 +1,6 @@
 import { Hallway } from "room-finder";
 
-export const COVID_ONE_WAY_HALLWAY_AND_STAIRS = true;
+export const COVID_ONE_WAY_HALLWAY_AND_STAIRS = false;
 
 export type StairNodeId =
   | "stair a"

--- a/tests/e2e/specs/test.js
+++ b/tests/e2e/specs/test.js
@@ -35,16 +35,16 @@ describe("Walnut.Direct Main Functionality", () => {
     cy.get("button").contains("Go").click();
     // We're in the directions page
     cy.url().should("contain", "/directions?fromRoom=3104&toRoom=3113");
-    cy.contains("p:nth-child(2)", "Turn left out of room 3104");
+    cy.contains("p:nth-child(1)", "Turn left out of room 3104");
     cy.contains(
-      "p:nth-child(3)",
+      "p:nth-child(2)",
       "Continue, then turn right (after passing room 3105 on your right)"
     );
     cy.contains(
-      "p:nth-child(4)",
+      "p:nth-child(3)",
       "Continue, then turn left (after passing room 3111 on your right)"
     );
-    cy.contains("p:nth-child(5)", "Continue, then turn right into room 3113");
+    cy.contains("p:nth-child(4)", "Continue, then turn right into room 3113");
     // Back button works
     cy.get("button").contains("Back").click();
     cy.contains("h1", "Where do you need to go?");

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -22,28 +22,21 @@ describe("App", () => {
 
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.find("p.direction-line:nth-child(1)").text())
-      .toMatchInlineSnapshot(`
-      "*Note: Based on COVID precautions, when our directions tell you
-              to turn left out of a room, you should instead turn
-              right out of the room, then make a U-turn at the end of the
-              hallway.
-              Similarly, when the directions tell you to turn left  
-              into a room, you should walk to the end of the hallway and make
-              a U-turn so you can come back and turn right into the room."
-    `);
+    expect(
+      wrapper.find("p.direction-line:nth-child(1)").text()
+    ).toMatchInlineSnapshot(`"Turn left out of room 3104"`);
     expect(
       wrapper.find("p.direction-line:nth-child(2)").text()
-    ).toMatchInlineSnapshot(`"Turn left out of room 3104*"`);
-    expect(
-      wrapper.find("p.direction-line:nth-child(3)").text()
     ).toMatchInlineSnapshot(
       `"Continue, then turn right (after passing room 3105 on your right)"`
     );
     expect(
-      wrapper.find("p.direction-line:nth-child(4)").text()
+      wrapper.find("p.direction-line:nth-child(3)").text()
     ).toMatchInlineSnapshot(
       `"Continue, then turn left (after passing room 3111 on your right)"`
     );
+    expect(
+      wrapper.find("p.direction-line:nth-child(4)").text()
+    ).toMatchInlineSnapshot(`"Continue, then turn right into room 3113"`);
   });
 });

--- a/tests/unit/__snapshots__/walnut-snapshot.spec.ts.snap
+++ b/tests/unit/__snapshots__/walnut-snapshot.spec.ts.snap
@@ -525,10 +525,11 @@ Continue, then turn left into room 3711"
 `;
 
 exports[`gives correct accessible directions from 2505 to 2209 1`] = `
-"Turn right out of room 2505
-Continue, then turn left into the door, and then turn right
-Go up the 3 steps
-Continue, then after entering the 2600s, turn left
+"Turn left out of room 2505
+Continue, then after entering Alumni Hall, turn left
+Continue, then after entering the arcade, turn left
+Go down the ramp, go through the arcade, and turn left into the 2600s (modern foreign languages wing)
+Continue straight
 Continue, then turn left (after passing room 2603 on your right)
 Continue, then turn right (after passing room 2604 on your left)
 Continue, then after entering the 2300s, turn left
@@ -536,14 +537,8 @@ Continue, then turn right into room 2209"
 `;
 
 exports[`gives correct accessible directions from 2510 to Black Box Theater 1`] = `
-"Turn right out of room 2510
-Continue, then turn left into the door, and then turn right
-Go up the 3 steps
-Continue, then after entering the 2600s, turn right
-Continue, then after entering the arcade, turn right, go to the end of the arcade, go up the ramp, and go through the doors on your right
-Continue straight
-Continue, then turn right into the narrow hallway
-Continue, then turn right into room 2503"
+"Turn left out of room 2510
+Continue, then turn left into room 2503"
 `;
 
 exports[`gives correct accessible directions from 2602 to Senior High Gym 1`] = `
@@ -871,13 +866,13 @@ Continue, then turn right (after passing the elevator on your left)
 Continue, then turn left into the 2600s
 Continue, then turn left
 Continue, then turn right (after passing room 2602 on your left)
-Continue, then turn right into the little hallway
-Go down the 3 steps
-Continue, then turn left into the door, and then turn left
-Continue, then go straight into the stairs
+Continue, then after entering the arcade, turn right, go to the end of the arcade, go up the ramp, and go through the doors on your right
+Continue straight
+Continue, then turn right into the narrow hallway
+Continue, then turn right into the corner with the stairs
+Continue, then turn right into the stairs
 Go up 1 floor of stairs
-Go straight out of the stairs
-Continue, then turn left into the corner with the stairs
+Turn right out of the stairs
 Continue, then go straight into room 3504"
 `;
 
@@ -1201,11 +1196,10 @@ Continue, then turn left (after passing room 3713 on your right)
 Continue, then turn right into the elevator
 Go to floor 2
 Turn right out of the elevator
-Continue, then after entering the arcade, go straight and a bit to the right to get to the 2600s, the modern languages wing
+Continue, then after entering the arcade, turn left
+Go to the end of the arcade, go up the ramp, and go through the doors on your right
 Continue straight
-Continue, then turn left into the little hallway
-Go down the 3 steps
-Continue, then turn left into the door, and then turn left
+Continue, then turn right into the narrow hallway
 Continue, then go straight into the stairs
 Go up 1 floor of stairs
 Go straight out of the stairs
@@ -1382,14 +1376,11 @@ Continue, then turn left into room 3205"
 
 exports[`gives correct directions from 1106 to 2709 1`] = `
 "Go straight out of room 1106
-Continue, then turn left into the early 1100s
-Continue, then turn left (after passing room 1105 on your left)
-Continue, then turn right into the stairs
+Continue, then turn left into the 2010 stairs
 Go up 1 floor of stairs
-Turn left out of the stairs
-Continue, then turn right into the stairs
-Go up 0.5 floor of stairs
-Turn right out of the 2015 stairs
+Turn right out of the 2010 stairs
+Continue, then turn right (after passing room 2111 on your left)
+Continue, then turn left (after passing room 2109 on your left)
 Continue, then turn right into the Alumni Hall
 Continue, then after entering the arcade, turn left
 Go down the ramp, go through the arcade, and turn right into the 2700s (science wing)
@@ -1398,15 +1389,12 @@ Continue, then turn left into room 2709"
 `;
 
 exports[`gives correct directions from 1109 to 2203 1`] = `
-"Turn left out of room 1109
-Continue, then turn right into the early 1100s
-Continue, then turn left (after passing room 1105 on your left)
-Continue, then turn right into the stairs
+"Turn right out of room 1109
+Continue, then turn left into the 2010 stairs
 Go up 1 floor of stairs
-Turn left out of the stairs
-Continue, then turn right into the stairs
-Go up 0.5 floor of stairs
-Turn right out of the 2015 stairs
+Turn right out of the 2010 stairs
+Continue, then turn right (after passing room 2111 on your left)
+Continue, then turn left (after passing room 2109 on your left)
 Continue, then turn left into room 2203"
 `;
 
@@ -1416,15 +1404,12 @@ Continue, then turn left into room 1107"
 `;
 
 exports[`gives correct directions from 1111 to 3713 1`] = `
-"Turn left out of room 1111
-Continue, then turn right into the early 1100s
-Continue, then turn left (after passing room 1105 on your left)
-Continue, then turn right into the stairs
+"Turn right out of room 1111
+Continue, then turn left into the 2010 stairs
 Go up 1 floor of stairs
-Turn left out of the stairs
-Continue, then turn right into the stairs
-Go up 0.5 floor of stairs
-Turn right out of the 2015 stairs
+Turn right out of the 2010 stairs
+Continue, then turn right (after passing room 2111 on your left)
+Continue, then turn left (after passing room 2109 on your left)
 Continue, then turn right into the Alumni Hall
 Continue, then after entering the arcade, turn left
 Go down the ramp, go through the arcade, and turn right into the 2700s (science wing)
@@ -1437,22 +1422,21 @@ Continue, then turn left into room 3713"
 
 exports[`gives correct directions from 1301 to 1450 1`] = `
 "Turn right out of room 1301
-Continue, then turn right into the cafeteria, and then turn left
-Continue, then turn left into the twisty hallway to the delivery hallway, and then turn right
-Continue, then turn right into the 1100s, and then turn left
-Go up the small set of stairs
 Continue, then turn left into the stairs
 Go up 1 floor of stairs
+Turn left out of the 2024 stairs
+Continue, then turn left into the 2015 stairs
+Go down 0.5 floor of stairs
 Turn left out of the stairs
-Continue, then turn right into the upper 1400s
+Continue, then turn left into the upper 1400s
 Continue, then turn left into room 1450"
 `;
 
 exports[`gives correct directions from 1301 to 2306 1`] = `
-"Turn right out of room 1301
-Continue, then turn left into the stairs
+"Turn left out of room 1301
+Continue, then turn right into the 2025 stairs
 Go up 1 floor of stairs
-Turn right out of the 2024 stairs
+Turn right out of the 2025 stairs
 Continue, then turn left (after passing the 2600s on your right)
 Continue, then turn left into room 2306"
 `;
@@ -1470,12 +1454,12 @@ exports[`gives correct directions from 1311 to 2701 1`] = `
 "Turn right out of room 1311
 Continue, then turn left (after passing room 1311 on your right)
 Continue, then turn right (after passing the elevator on your left)
+Continue, then turn left into the 1600s
+Continue, then turn left
+Continue, then turn right (after passing room 1602 on your left)
 Continue, then turn left into the stairs
 Go up 1 floor of stairs
-Turn left out of the 2024 stairs
-Continue, then turn left into the Alumni Hall
-Continue, then after entering the arcade, turn left
-Go down the ramp, go through the arcade, and turn right into the 2700s (science wing)
+Turn left out of the stairs
 Continue, then turn left into room 2701"
 `;
 
@@ -1484,32 +1468,33 @@ exports[`gives correct directions from 1312 to 3115 1`] = `
 Continue, then turn left (after passing room 1311 on your right)
 Continue, then turn right (after passing the elevator on your left)
 Continue, then turn left into the stairs
-Go up 2 floors of stairs
+Go up 1 floor of stairs
 Turn left out of the 2024 stairs
-Continue, then turn right (after passing room 3105 on your right)
-Continue, then turn left (after passing room 3111 on your right)
-Continue, then turn right into room 3115"
+Continue, then turn right (after passing the elevator on your left)
+Continue, then turn left (after passing room 2110 on your right)
+Continue, then turn left into the 2010 stairs
+Go up 1 floor of stairs
+Turn right out of the 2010 stairs
+Continue, then turn left into room 3115"
 `;
 
 exports[`gives correct directions from 1313 to 3302 1`] = `
 "Turn right out of room 1313
 Continue, then turn left (after passing room 1311 on your right)
 Continue, then turn right (after passing the elevator on your left)
-Continue, then turn left into the stairs
+Continue, then turn left into the 2025 stairs
 Go up 2 floors of stairs
-Turn right out of the 2024 stairs
-Continue, then turn right into room 3302"
+Turn left out of the 2025 stairs
+Continue, then turn left into room 3302"
 `;
 
 exports[`gives correct directions from 1315 to 3310 1`] = `
-"Turn right out of room 1315
-Continue, then turn left (after passing room 1311 on your right)
-Continue, then turn right (after passing the elevator on your left)
-Continue, then turn left into the stairs
+"Turn left out of room 1315
+Continue, then turn right into the 2018 stairs
 Go up 2 floors of stairs
-Turn right out of the 2024 stairs
-Continue, then turn left (after passing the 2025 stairs on your right)
-Continue, then turn left into room 3310"
+Turn left out of the 2018 stairs
+Continue, then turn left (after passing room 3311 on your right)
+Continue, then turn right into room 3310"
 `;
 
 exports[`gives correct directions from 1450 to 1111 1`] = `
@@ -1572,13 +1557,13 @@ exports[`gives correct directions from 1606 to 2311 1`] = `
 "Turn right out of room 1606
 Continue, then turn left (after passing room 1604 on your left)
 Continue, then turn right (after passing room 1601 on your right)
-Continue, then after entering the 1300s, turn left
-Continue, then turn left into the stairs
+Continue, then after entering the 1300s, turn right
+Continue, then turn left (after passing the 1600s on your right)
+Continue, then turn right (after passing room 1310 on your left)
+Continue, then turn right into the 2018 stairs
 Go up 1 floor of stairs
-Turn right out of the 2024 stairs
-Continue, then turn left (after passing the 2600s on your right)
-Continue, then turn right (after passing room 2306 on your left)
-Continue, then turn left into room 2311"
+Turn left out of the 2018 stairs
+Continue, then turn right into room 2311"
 `;
 
 exports[`gives correct directions from 1608 to 1108 1`] = `
@@ -1616,13 +1601,10 @@ Continue, then turn right
 Continue, then go straight into the stairs
 Go up 1 floor of stairs
 Turn right out of the stairs
-Continue, then turn left (after passing the Senior High Gym on your right)
-Continue, then turn left into the doors labeled \\"Music Lyceum\\", and then turn right
-Continue, then go straight into the stairs
+Continue, then turn left into the stairs
 Go up 1 floor of stairs
-Turn left out of the stairs
-Continue, then turn left (after passing room 2848 on your right)
-Continue, then turn right into room 2846"
+Go straight out of the stairs
+Continue, then turn left into room 2846"
 `;
 
 exports[`gives correct directions from 1841 to 2840 1`] = `
@@ -1632,13 +1614,10 @@ Continue, then turn right
 Continue, then go straight into the stairs
 Go up 1 floor of stairs
 Turn right out of the stairs
-Continue, then turn left (after passing the Senior High Gym on your right)
-Continue, then turn left into the doors labeled \\"Music Lyceum\\", and then turn right
-Continue, then go straight into the stairs
+Continue, then turn left into the stairs
 Go up 1 floor of stairs
-Turn left out of the stairs
-Continue, then turn left (after passing room 2848 on your right)
-Continue, then turn right into room 2840"
+Go straight out of the stairs
+Continue, then turn left into room 2840"
 `;
 
 exports[`gives correct directions from 1842 to 2714 1`] = `
@@ -1655,15 +1634,12 @@ Continue, then turn right into room 2714"
 `;
 
 exports[`gives correct directions from 1850 to 2849 1`] = `
-"Turn right out of room 1850
-Continue, then after entering the early 1800s, turn left
-Continue, then turn right (after passing room 1823 on your right)
+"Turn left out of room 1850
+Continue, then turn right (after passing room 1853 on your left)
 Continue, then turn right
 Continue, then go straight into the stairs
 Go up 1 floor of stairs
-Turn right out of the stairs
-Continue, then turn left (after passing the Senior High Gym on your right)
-Continue, then turn left into the doors labeled \\"Music Lyceum\\", and then turn right
+Go straight out of the stairs
 Continue, then go straight into the stairs
 Go up 1 floor of stairs
 Turn left out of the stairs
@@ -1671,36 +1647,32 @@ Continue, then turn left into room 2849"
 `;
 
 exports[`gives correct directions from 1851 to 3111 1`] = `
-"Turn right out of room 1851
-Continue, then after entering the early 1800s, turn left
-Continue, then turn right (after passing room 1823 on your right)
+"Turn left out of room 1851
+Continue, then turn right (after passing room 1853 on your left)
 Continue, then turn right
 Continue, then go straight into the stairs
 Go up 1 floor of stairs
-Turn right out of the stairs
-Continue, then turn left (after passing the Senior High Gym on your right)
+Go straight out of the stairs
+Continue, then turn right into the long narrow hallway, and then turn left
 Continue, then after entering the arcade, turn left and go to the end of the arcade
 Go up the ramp, then go through the doors on your right
 Continue straight
 Continue, then after entering the 2200s, turn left
-Continue, then turn left into the 2015 stairs
+Continue, then turn right (after passing the elevator on your left)
+Continue, then turn left (after passing room 2110 on your right)
+Continue, then turn left into the 2010 stairs
 Go up 1 floor of stairs
-Turn left out of the 2015 stairs
-Continue, then turn right (after passing room 3105 on your right)
-Continue, then turn right into room 3111"
+Turn right out of the 2010 stairs
+Continue, then turn right (after passing room 3113 on your left)
+Continue, then turn left into room 3111"
 `;
 
 exports[`gives correct directions from 1852 to 2404 1`] = `
-"Turn right out of room 1852
-Continue, then turn left (after passing room 1852 on your right)
-Continue, then turn left
-Continue, then after entering the early 1800s, turn left
-Continue, then turn right (after passing room 1823 on your right)
-Continue, then turn right
+"Turn left out of room 1852
 Continue, then go straight into the stairs
 Go up 1 floor of stairs
-Turn right out of the stairs
-Continue, then turn left (after passing the Senior High Gym on your right)
+Go straight out of the stairs
+Continue, then turn right into the long narrow hallway, and then turn left
 Continue, then after entering the arcade, turn left and go to the end of the arcade
 Go up the ramp, then go through the doors on your right
 Continue straight
@@ -1718,18 +1690,18 @@ Continue, then turn right into room 2113"
 
 exports[`gives correct directions from 2103 to 1305 1`] = `
 "Turn left out of room 2103
-Continue, then turn right into the 2025 stairs
+Continue, then turn right into the 2024 stairs
 Go down 1 floor of stairs
-Turn left out of the 2025 stairs
-Continue, then turn right into room 1305"
+Turn right out of the stairs
+Continue, then turn left into room 1305"
 `;
 
 exports[`gives correct directions from 2109 to 1605 1`] = `
 "Turn left out of room 2109
 Continue, then turn left (after passing room 2109 on your left)
-Continue, then turn right into the 2025 stairs
+Continue, then turn right into the 2024 stairs
 Go down 1 floor of stairs
-Turn right out of the 2025 stairs
+Turn right out of the stairs
 Continue, then turn right into the 1600s
 Continue, then turn left
 Continue, then turn right (after passing room 1602 on your left)
@@ -1767,10 +1739,15 @@ Continue, then turn left into room 2723"
 
 exports[`gives correct directions from 2205 to 2719 1`] = `
 "Turn left out of room 2205
-Continue, then turn right into the 2600s
+Continue, then turn right into the 2025 stairs
+Go down 1 floor of stairs
+Turn right out of the 2025 stairs
+Continue, then turn right into the 1600s
 Continue, then turn left
-Continue, then turn right (after passing room 2602 on your left)
-Continue, then after entering the arcade, go straight and a bit to the right to get to the 2700s, the science wing
+Continue, then turn right (after passing room 1602 on your left)
+Continue, then turn left into the stairs
+Go up 1 floor of stairs
+Turn left out of the stairs
 Continue, then turn right (after passing room 2715 on your left)
 Continue, then turn left into room 2719"
 `;
@@ -1840,25 +1817,24 @@ Continue, then after entering the arcade, turn left
 Go down the ramp, and go all the way to the other end of the arcade
 Turn right to get to the long narrow hallway
 Continue straight
-Continue, then turn right into the doors labeled \\"Music Lyceum\\", and then turn left
-Continue, then go straight into the stairs
+Continue, then turn right (after passing the doors labeled \\"Music Lyceum\\" on your right)
+Continue, then turn left into the stairs
 Go down 1 floor of stairs
 Go straight out of the stairs
-Continue, then turn left (after passing room 1852 on your right)
 Continue, then turn left
-Continue, then after entering the early 1800s, turn left
-Continue, then turn right into room 1824"
+Continue, then turn left
+Continue, then turn left into room 1824"
 `;
 
 exports[`gives correct directions from 2222 to 3314 1`] = `
 "Exit room 2222, and then turn right
 Continue, then after entering the lobby, turn left
-Continue, then turn right into the 2024 stairs
+Continue, then turn left (after passing the 2600s on your right)
+Continue, then turn right (after passing room 2306 on your left)
+Continue, then turn right into the 2018 stairs
 Go up 1 floor of stairs
-Turn right out of the 2024 stairs
-Continue, then turn left (after passing the 2025 stairs on your right)
-Continue, then turn right (after passing room 3310 on your left)
-Continue, then turn right into room 3314"
+Turn left out of the 2018 stairs
+Continue, then turn left into room 3314"
 `;
 
 exports[`gives correct directions from 2229 to 2716 1`] = `
@@ -1879,13 +1855,12 @@ Continue, then after entering the arcade, turn left
 Go down the ramp, and go all the way to the other end of the arcade
 Turn right to get to the long narrow hallway
 Continue straight
-Continue, then turn right into the doors labeled \\"Music Lyceum\\", and then turn left
-Continue, then go straight into the stairs
+Continue, then turn right (after passing the doors labeled \\"Music Lyceum\\" on your right)
+Continue, then turn left into the stairs
 Go down 1 floor of stairs
 Go straight out of the stairs
-Continue, then turn left (after passing room 1852 on your right)
 Continue, then turn left
-Continue, then after entering the early 1800s, turn right
+Continue, then turn left
 Continue, then turn right into room 1846"
 `;
 
@@ -1902,25 +1877,15 @@ Continue, then turn left into room 3711"
 `;
 
 exports[`gives correct directions from 2505 to 2209 1`] = `
-"Turn right out of room 2505
-Continue, then turn left into the door, and then turn right
-Go up the 3 steps
-Continue, then after entering the 2600s, turn left
-Continue, then turn left (after passing room 2603 on your right)
-Continue, then turn right (after passing room 2604 on your left)
-Continue, then after entering the 2300s, turn left
+"Turn left out of room 2505
+Continue, then after entering Alumni Hall, turn right
+Continue, then after entering the 2200s, turn left
 Continue, then turn right into room 2209"
 `;
 
 exports[`gives correct directions from 2510 to Black Box Theater 1`] = `
-"Turn right out of room 2510
-Continue, then turn left into the door, and then turn right
-Go up the 3 steps
-Continue, then after entering the 2600s, turn right
-Continue, then after entering the arcade, turn right, go to the end of the arcade, go up the ramp, and go through the doors on your right
-Continue straight
-Continue, then turn right into the narrow hallway
-Continue, then turn right into room 2503"
+"Turn left out of room 2510
+Continue, then turn left into room 2503"
 `;
 
 exports[`gives correct directions from 2602 to Senior High Gym 1`] = `
@@ -1953,26 +1918,26 @@ exports[`gives correct directions from 2607 to 3315 1`] = `
 "Turn right out of room 2607
 Continue, then turn left (after passing room 2603 on your right)
 Continue, then turn right (after passing room 2604 on your left)
-Continue, then after entering the 2300s, turn left
-Continue, then turn left into the 2024 stairs
+Continue, then after entering the 2300s, turn right
+Continue, then turn left (after passing the 2600s on your right)
+Continue, then turn right (after passing room 2306 on your left)
+Continue, then turn right into the 2018 stairs
 Go up 1 floor of stairs
-Turn right out of the 2024 stairs
-Continue, then turn left (after passing the 2025 stairs on your right)
-Continue, then turn right (after passing room 3310 on your left)
-Continue, then turn left into room 3315"
+Turn left out of the 2018 stairs
+Continue, then turn right into room 3315"
 `;
 
 exports[`gives correct directions from 2609 to 3312 1`] = `
 "Turn right out of room 2609
 Continue, then turn left (after passing room 2603 on your right)
 Continue, then turn right (after passing room 2604 on your left)
-Continue, then after entering the 2300s, turn left
-Continue, then turn left into the 2024 stairs
+Continue, then after entering the 2300s, turn right
+Continue, then turn left (after passing the 2600s on your right)
+Continue, then turn right (after passing room 2306 on your left)
+Continue, then turn right into the 2018 stairs
 Go up 1 floor of stairs
-Turn right out of the 2024 stairs
-Continue, then turn left (after passing the 2025 stairs on your right)
-Continue, then turn right (after passing room 3310 on your left)
-Continue, then turn right into room 3312"
+Turn left out of the 2018 stairs
+Continue, then turn left into room 3312"
 `;
 
 exports[`gives correct directions from 2611 to 2307 1`] = `
@@ -1993,9 +1958,9 @@ Turn right out of the stairs
 Continue, then turn left (after passing room 1604 on your left)
 Continue, then turn right (after passing room 1601 on your right)
 Continue, then after entering the 1300s, turn left
-Continue, then turn left into the stairs
+Continue, then turn left into the 2025 stairs
 Go up 2 floors of stairs
-Turn left out of the 2024 stairs
+Turn left out of the 2025 stairs
 Continue, then turn left into room 3207"
 `;
 
@@ -2010,18 +1975,16 @@ Continue, then turn right into room 2505"
 
 exports[`gives correct directions from 2704 to 3114 1`] = `
 "Turn left out of room 2704
-Continue, then turn right into the stairs
-Go down 1 floor of stairs
-Turn right out of the stairs
-Continue, then turn left (after passing room 1604 on your left)
-Continue, then turn right (after passing room 1601 on your right)
-Continue, then after entering the 1300s, turn left
-Continue, then turn left into the stairs
-Go up 2 floors of stairs
-Turn left out of the 2024 stairs
-Continue, then turn right (after passing room 3105 on your right)
-Continue, then turn left (after passing room 3111 on your right)
-Continue, then turn left into room 3114"
+Continue, then after entering the arcade, turn left
+Go to the end of the arcade, go up the ramp, and go through the doors on your right
+Continue straight
+Continue, then after entering the 2200s, turn left
+Continue, then turn right (after passing the elevator on your left)
+Continue, then turn left (after passing room 2110 on your right)
+Continue, then turn left into the 2010 stairs
+Go up 1 floor of stairs
+Turn right out of the 2010 stairs
+Continue, then turn right into room 3114"
 `;
 
 exports[`gives correct directions from 2705 to 2707 1`] = `
@@ -2116,15 +2079,12 @@ exports[`gives correct directions from 2844 to 1845 1`] = `
 "Turn right out of room 2844
 Continue, then go straight into the stairs
 Go down 1 floor of stairs
-Turn left out of the stairs
-Continue, then turn left (after passing the Senior High Gym on your right)
-Continue, then turn left into the doors labeled \\"Music Lyceum\\", and then turn left
-Continue, then go straight into the stairs
+Turn right out of the stairs
+Continue, then turn left into the stairs
 Go down 1 floor of stairs
 Go straight out of the stairs
-Continue, then turn left (after passing room 1852 on your right)
 Continue, then turn left
-Continue, then after entering the early 1800s, turn right
+Continue, then turn left
 Continue, then go straight into room 1845"
 `;
 
@@ -2201,13 +2161,14 @@ Continue, then after entering the arcade, turn left and go to the end of the arc
 Go up the ramp, then go through the doors on your right
 Continue straight
 Continue, then after entering the 2200s, turn left
-Continue, then turn right (after passing the elevator on your left)
-Continue, then turn left (after passing room 2110 on your right)
-Continue, then turn left into the 2010 stairs
+Continue, then turn left into the 2015 stairs
+Go down 0.5 floor of stairs
+Turn left out of the stairs
+Continue, then turn right into the stairs
 Go down 1 floor of stairs
-Turn right out of the 2010 stairs
-Continue, then turn right into the early 1100s
-Continue, then turn left into room 1105"
+Turn left out of the stairs
+Continue, then turn right (after passing the elevator on your left)
+Continue, then turn right into room 1105"
 `;
 
 exports[`gives correct directions from 3101 to Language Lab 1`] = `
@@ -2235,25 +2196,20 @@ Continue, then after entering the arcade, turn left
 Go down the ramp, and go all the way to the other end of the arcade
 Turn right to get to the long narrow hallway
 Continue straight
-Continue, then turn right into the doors labeled \\"Music Lyceum\\", and then turn right
-Continue, then go straight into the stairs
+Continue, then turn right (after passing the doors labeled \\"Music Lyceum\\" on your right)
+Continue, then turn right into the stairs
 Go up 1 floor of stairs
-Turn left out of the stairs
-Continue, then turn left (after passing room 2848 on your right)
-Continue, then turn right into room 2840"
+Go straight out of the stairs
+Continue, then turn left into room 2840"
 `;
 
 exports[`gives correct directions from 3104 to 3104 1`] = `"Bruh. You at room 3104"`;
 
 exports[`gives correct directions from 3104 to 3504 1`] = `
-"Turn left out of room 3104
-Continue, then turn right (after passing room 3105 on your right)
-Continue, then turn left (after passing room 3111 on your right)
-Continue, then turn left into the 2010 stairs
+"Turn right out of room 3104
+Continue, then turn right into the 2015 stairs
 Go down 1 floor of stairs
-Turn right out of the 2010 stairs
-Continue, then turn right (after passing room 2111 on your left)
-Continue, then turn left (after passing room 2109 on your left)
+Turn right out of the 2015 stairs
 Continue, then turn right into the Alumni Hall
 Continue, then turn left into the narrow hallway
 Continue, then turn right into the corner with the stairs
@@ -2325,40 +2281,39 @@ Continue, then turn left into room 1607"
 
 exports[`gives correct directions from 3202 to 2114 1`] = `
 "Turn left out of room 3202
-Continue, then turn right (after passing room 3105 on your right)
-Continue, then turn left (after passing room 3111 on your right)
-Continue, then turn left into the 2010 stairs
+Continue, then turn left into the 2015 stairs
 Go down 1 floor of stairs
-Turn right out of the 2010 stairs
-Continue, then turn right into room 2114"
+Turn left out of the 2015 stairs
+Continue, then turn right (after passing the elevator on your left)
+Continue, then turn left (after passing room 2110 on your right)
+Continue, then turn left into room 2114"
 `;
 
 exports[`gives correct directions from 3204 to 2212 1`] = `
-"Turn right out of room 3204
-Continue, then turn right into the 2025 stairs
+"Turn left out of room 3204
+Continue, then turn left into the 2015 stairs
 Go down 1 floor of stairs
-Turn left out of the 2025 stairs
-Continue, then turn right into the 2200s
+Turn right out of the 2015 stairs
+Continue, then turn left into the 2200s
 Continue, then turn left into room 2212"
 `;
 
 exports[`gives correct directions from 3206 to 1849 1`] = `
 "Turn right out of room 3206
-Continue, then turn right into the 2025 stairs
+Continue, then turn right into the 2024 stairs
 Go down 1 floor of stairs
-Turn right out of the 2025 stairs
-Continue, then turn right into the 2600s
-Continue, then turn left
-Continue, then turn right (after passing room 2602 on your left)
-Continue, then after entering the arcade, go straight and a bit to the left to get to the long narrow hallway
+Turn left out of the 2024 stairs
+Continue, then turn left into the Alumni Hall
+Continue, then after entering the arcade, turn left
+Go down the ramp, and go all the way to the other end of the arcade
+Turn right to get to the long narrow hallway
 Continue straight
-Continue, then turn right into the doors labeled \\"Music Lyceum\\", and then turn left
-Continue, then go straight into the stairs
+Continue, then turn right (after passing the doors labeled \\"Music Lyceum\\" on your right)
+Continue, then turn left into the stairs
 Go down 1 floor of stairs
 Go straight out of the stairs
-Continue, then turn left (after passing room 1852 on your right)
 Continue, then turn left
-Continue, then after entering the early 1800s, turn right
+Continue, then turn left
 Continue, then turn right into room 1849"
 `;
 
@@ -2374,9 +2329,9 @@ Continue, then turn left into room 2309"
 
 exports[`gives correct directions from 3210 to Black Box Theater 1`] = `
 "Turn right out of room 3210
-Continue, then turn right into the 2025 stairs
+Continue, then turn right into the 2024 stairs
 Go down 1 floor of stairs
-Turn left out of the 2025 stairs
+Turn left out of the 2024 stairs
 Continue, then turn left into the Alumni Hall
 Continue, then turn left into the narrow hallway
 Continue, then turn right into room 2503"
@@ -2392,21 +2347,20 @@ Continue, then turn left
 Continue, then turn right (after passing room 2602 on your left)
 Continue, then after entering the arcade, go straight and a bit to the left to get to the long narrow hallway
 Continue straight
-Continue, then turn right into the doors labeled \\"Music Lyceum\\", and then turn left
-Continue, then go straight into the stairs
+Continue, then turn right (after passing the doors labeled \\"Music Lyceum\\" on your right)
+Continue, then turn left into the stairs
 Go down 1 floor of stairs
 Go straight out of the stairs
-Continue, then turn left (after passing room 1852 on your right)
 Continue, then turn left
-Continue, then after entering the early 1800s, turn left
-Continue, then turn left into room 1843"
+Continue, then turn left
+Continue, then turn right into room 1843"
 `;
 
 exports[`gives correct directions from 3303 to Athletic Director's Office 1`] = `
-"Turn left out of room 3303
-Continue, then turn right into the 2025 stairs
+"Turn right out of room 3303
+Continue, then turn left into the 2015 stairs
 Go down 1 floor of stairs
-Turn left out of the 2025 stairs
+Turn left out of the 2015 stairs
 Continue, then turn left into the tiny hallway that's across from room 2101
 Continue, then turn left into room 2401"
 `;
@@ -2459,38 +2413,32 @@ exports[`gives correct directions from 3313 to 2105 1`] = `
 "Turn right out of room 3313
 Continue, then turn left (after passing room 3311 on your right)
 Continue, then turn right (after passing the elevator on your left)
-Continue, then turn left into the 2025 stairs
+Continue, then turn left into the 2015 stairs
 Go down 1 floor of stairs
-Turn left out of the 2025 stairs
+Turn left out of the 2015 stairs
 Continue, then turn right into room 2105"
 `;
 
 exports[`gives correct directions from 3701 to Computer Lab 1`] = `
-"Turn left out of room 3701
-Continue, then turn right (after passing room 3711 on your left)
-Continue, then turn left into the stairs
-Go down 1 floor of stairs
-Turn right out of the stairs
-Continue, then turn left (after passing room 2717 on your right)
+"Turn right out of room 3701
 Continue, then turn right into the stairs
 Go down 1 floor of stairs
 Turn right out of the stairs
-Continue, then turn left (after passing room 1604 on your left)
-Continue, then turn right (after passing room 1601 on your right)
-Continue, then after entering the 1300s, turn left
-Continue, then turn left into the stairs
-Go up 2 floors of stairs
-Turn left out of the 2024 stairs
+Continue, then after entering the arcade, turn left
+Go to the end of the arcade, go up the ramp, and go through the doors on your right
+Continue straight
+Continue, then after entering the 2200s, turn left
+Continue, then turn left into the 2015 stairs
+Go up 1 floor of stairs
+Turn left out of the 2015 stairs
 Continue, then turn left into room 3104"
 `;
 
 exports[`gives correct directions from 3702 to 3503 1`] = `
-"Turn right out of room 3702
-Continue, then turn right (after passing room 3711 on your left)
-Continue, then turn left into the stairs
+"Turn left out of room 3702
+Continue, then turn right into the stairs
 Go down 1 floor of stairs
 Turn right out of the stairs
-Continue, then turn left (after passing room 2717 on your right)
 Continue, then after entering the arcade, turn left
 Go to the end of the arcade, go up the ramp, and go through the doors on your right
 Continue straight
@@ -2503,12 +2451,10 @@ Continue, then turn left into room 3503"
 `;
 
 exports[`gives correct directions from 3703 to 1853 1`] = `
-"Turn left out of room 3703
-Continue, then turn right (after passing room 3711 on your left)
-Continue, then turn left into the stairs
+"Turn right out of room 3703
+Continue, then turn right into the stairs
 Go down 1 floor of stairs
 Turn right out of the stairs
-Continue, then turn left (after passing room 2717 on your right)
 Continue, then after entering the arcade, turn right
 Go to the end of the arcade and turn right into the narrow hallway
 Continue straight
@@ -2522,13 +2468,11 @@ Continue, then turn right into room 1853"
 `;
 
 exports[`gives correct directions from 3704 to 1300 1`] = `
-"Turn right out of room 3704
-Continue, then turn right (after passing room 3711 on your left)
-Continue, then turn left into the stairs
-Go down 1 floor of stairs
-Turn right out of the stairs
-Continue, then turn left (after passing room 2717 on your right)
+"Turn left out of room 3704
 Continue, then turn right into the stairs
+Go down 1 floor of stairs
+Turn left out of the stairs
+Continue, then turn left into the stairs
 Go down 1 floor of stairs
 Turn right out of the stairs
 Continue, then turn left (after passing room 1604 on your left)
@@ -2538,33 +2482,29 @@ Continue, then turn left into room 1300"
 `;
 
 exports[`gives correct directions from 3707 to 3113 1`] = `
-"Turn left out of room 3707
-Continue, then turn right (after passing room 3711 on your left)
-Continue, then turn left into the stairs
-Go down 1 floor of stairs
-Turn right out of the stairs
-Continue, then turn left (after passing room 2717 on your right)
+"Turn right out of room 3707
 Continue, then turn right into the stairs
 Go down 1 floor of stairs
 Turn right out of the stairs
-Continue, then turn left (after passing room 1604 on your left)
-Continue, then turn right (after passing room 1601 on your right)
-Continue, then after entering the 1300s, turn left
-Continue, then turn left into the stairs
-Go up 2 floors of stairs
-Turn left out of the 2024 stairs
-Continue, then turn right (after passing room 3105 on your right)
-Continue, then turn left (after passing room 3111 on your right)
-Continue, then turn right into room 3113"
+Continue, then after entering the arcade, turn left
+Go to the end of the arcade, go up the ramp, and go through the doors on your right
+Continue straight
+Continue, then after entering the 2200s, turn left
+Continue, then turn right (after passing the elevator on your left)
+Continue, then turn left (after passing room 2110 on your right)
+Continue, then turn left into the 2010 stairs
+Go up 1 floor of stairs
+Turn right out of the 2010 stairs
+Continue, then turn left into room 3113"
 `;
 
 exports[`gives correct directions from 3714 to 1310 1`] = `
-"Turn right out of room 3714
-Continue, then turn left into the stairs
-Go down 1 floor of stairs
-Turn right out of the stairs
-Continue, then turn left (after passing room 2717 on your right)
+"Turn left out of room 3714
+Continue, then turn left (after passing room 3713 on your right)
 Continue, then turn right into the stairs
+Go down 1 floor of stairs
+Turn left out of the stairs
+Continue, then turn left into the stairs
 Go down 1 floor of stairs
 Turn right out of the stairs
 Continue, then turn left (after passing room 1604 on your left)
@@ -2575,11 +2515,11 @@ Continue, then turn left into room 1310"
 `;
 
 exports[`gives correct directions from 3715 to 3505 1`] = `
-"Turn left out of room 3715
-Continue, then turn left into the stairs
+"Turn right out of room 3715
+Continue, then turn left (after passing room 3713 on your right)
+Continue, then turn right into the stairs
 Go down 1 floor of stairs
 Turn right out of the stairs
-Continue, then turn left (after passing room 2717 on your right)
 Continue, then after entering the arcade, go straight and a bit to the right to get to the 2600s, the modern languages wing
 Continue straight
 Continue, then turn left into the little hallway
@@ -2599,11 +2539,12 @@ Continue, then after entering the arcade, turn left
 Go down the ramp, and go all the way to the other end of the arcade
 Turn right to get to the long narrow hallway
 Continue straight
-Continue, then turn right into the doors labeled \\"Music Lyceum\\", and then turn right
-Continue, then go straight into the stairs
+Continue, then turn right (after passing the doors labeled \\"Music Lyceum\\" on your right)
+Continue, then turn right into the stairs
 Go up 1 floor of stairs
-Turn left out of the stairs
-Continue, then turn right into room 2848"
+Go straight out of the stairs
+Continue, then turn right (after passing room 2846 on your left)
+Continue, then turn left into room 2848"
 `;
 
 exports[`gives correct directions from Band (1845) to Black Box Theater 1`] = `
@@ -2632,10 +2573,10 @@ Continue, then turn left into room 2722"
 
 exports[`gives correct directions from Conference Room to 1303 1`] = `
 "Turn right out of room 2210
-Continue, then turn right into the 2025 stairs
+Continue, then turn right into the 2024 stairs
 Go down 1 floor of stairs
-Turn left out of the 2025 stairs
-Continue, then turn right into room 1303"
+Turn right out of the stairs
+Continue, then turn left into room 1303"
 `;
 
 exports[`gives correct directions from Fitness Room to 1101 1`] = `
@@ -2657,12 +2598,14 @@ Continue, then turn left into room 3102"
 
 exports[`gives correct directions from Junior High Gym to 3112 1`] = `
 "Go straight out of the Junior High Gym
-Continue, then after entering the 2100s, turn right
-Continue, then turn right into the 2015 stairs
+Continue, then after entering the 2100s, turn left
+Continue, then turn right (after passing the elevator on your left)
+Continue, then turn left (after passing room 2110 on your right)
+Continue, then turn left into the 2010 stairs
 Go up 1 floor of stairs
-Turn left out of the 2015 stairs
-Continue, then turn right (after passing room 3105 on your right)
-Continue, then turn left into room 3112"
+Turn right out of the 2010 stairs
+Continue, then turn right (after passing room 3113 on your left)
+Continue, then turn right into room 3112"
 `;
 
 exports[`gives correct directions from Medical Room to 2112 1`] = `
@@ -2728,23 +2671,20 @@ exports[`gives correct directions from Strings to Band (1840) 1`] = `
 Continue, then turn left (after passing room 2848 on your right)
 Continue, then go straight into the stairs
 Go down 1 floor of stairs
-Turn left out of the stairs
-Continue, then turn left (after passing the Senior High Gym on your right)
-Continue, then turn left into the doors labeled \\"Music Lyceum\\", and then turn left
-Continue, then go straight into the stairs
+Turn right out of the stairs
+Continue, then turn left into the stairs
 Go down 1 floor of stairs
 Go straight out of the stairs
-Continue, then turn left (after passing room 1852 on your right)
 Continue, then turn left
-Continue, then after entering the early 1800s, turn left
-Continue, then turn right into room 1840"
+Continue, then turn left
+Continue, then turn left into room 1840"
 `;
 
 exports[`gives correct directions from Writing Center to Registrar 1`] = `
-"Turn left out of room 3301
-Continue, then turn right into the 2025 stairs
+"Turn right out of room 3301
+Continue, then turn left into the 2024 stairs
 Go down 1 floor of stairs
-Turn left out of the 2025 stairs
+Turn left out of the 2024 stairs
 Continue, then turn right into the 2200s
 Continue, then turn left into room 2216"
 `;


### PR DESCRIPTION
**Merge this pull request once the COVID precautions for staircases and hallways are no longer in place.** (And if you don't know whether they are, you might want to ask someone.) @regexBuster @lizavolo @louiske65 @wowannie 

This pull request sets `COVID_ONE_WAY_HALLWAY_AND_STAIRS` to `false`, then fixes the broken test cases.

---

However, this pull request does **not** modify the "COVID-19 Updates" section at the top of the main page. 

- If you want to modify the status update, edit [/src/components/StatusUpdates.vue](https://github.com/WalnutProgramming/Directions/blob/master/src/components/StatusUpdates.vue).
- If you want to remove the status update, remove the `<StatusUpdates />` line in [/src/views/IndexPage.vue](https://github.com/WalnutProgramming/Directions/blob/master/src/views/IndexPage.vue). Once you've done that, if you want, you can also delete the whole [/src/components/StatusUpdates.vue](https://github.com/WalnutProgramming/Directions/blob/master/src/components/StatusUpdates.vue) file.