### PR TITLE
Make link to PDF work in Android Chrome

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,6 +16,7 @@
             >
           </li>
           <li>
+            <!-- https://stackoverflow.com/a/9996059 -->
             <a
               href="https://docs.google.com/gview?embedded=true&url=http://www.walnuthillseagles.com/news-pdfs/2013/WHHS_Floor_Maps.pdf"
               >Floor Map</a

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,7 @@
           </li>
           <li>
             <a
-              href="http://www.walnuthillseagles.com/news-pdfs/2013/WHHS_Floor_Maps.pdf"
+              href="https://docs.google.com/gview?embedded=true&url=http://www.walnuthillseagles.com/news-pdfs/2013/WHHS_Floor_Maps.pdf"
               >Floor Map</a
             >
           </li>


### PR DESCRIPTION
Android Chrome doesn't support PDFs, so we use the Google Docs viewer

<https://stackoverflow.com/a/9996059>

<https://docs.google.com/gview?embedded=true&url=http://www.walnuthillseagles.com/news-pdfs/2013/WHHS_Floor_Maps.pdf>